### PR TITLE
Batch logs per topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ target/*
 .project
 .settings/
 .vscode/
-test/*
 .DS_Store
 settings.xml

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ transforms.addExtraField.static.value=extraValue
 Now if you restart the sink connector and send some more test messages, each new record should have a `extraField` field 
 with value `value`. For more in-depth video, see [confluent's documentation](https://docs.confluent.io/current/connect/transforms/index.html).
 
+## System Tests
+
+In the `/test` directory there are some `.json` configuration files to make it easy to create Connectors for testing in 
+[Confluent Platform](https://docs.confluent.io/current/quickstart/ce-quickstart.html). Testing can be done using the 
+[Confluent Kafka Datagen Connector](https://github.com/confluentinc/kafka-connect-datagen) to create sample data and 
+adding the Datadog Logs Connector after installing it. Confluent Platform provides an easy way to spin up a 
+batteries-included Kafka environment for local testing.
+
 ## License
 
 Datadog Kafka Connect Logs is licensed under the Apache License 2.0. Details can be found in the file LICENSE.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ set your Datadog `api_key`.
     "name": "datadog-kafka-connect-logs",
     "config": {
       "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+      "datadog.api_key": "<YOUR_API_KEY>",
       "tasks.max": "3",
       "topics":"<YOUR_TOPIC>",
     }
   }'    
 ```
 
-7. You can verify that data is ingested to the Datadog platform by searching for `kafka-connect` as the `ddsource`.
+7. You can verify that data is ingested to the Datadog platform by searching for `source:kafka-connect` in the Log 
+Explorer tab
 8. Use the following commands to check status, and manage connectors and tasks:
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ community connectors.
 1. Clone the repo from https://github.com/DataDog/datadog-kafka-connect-logs
 2. Verify that Java8 JRE or JDK is installed.
 3. Run `mvn clean compile package`. This will build the jar in the `/target` directory. The name will be `datadog-kafka-connect-logs-[VERSION].jar`.
-4. The jar file for use on [Confluent Hub](https://www.confluent.io/hub/) can be found in `target/components/packages`.
+4. The zip file for use on [Confluent Hub](https://www.confluent.io/hub/) can be found in `target/components/packages`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A REST call can be executed against one of the cluster instances, and the config
 | `datadog.tags` | Tags associated with your logs in a comma separated tag:value format.||
 | `datadog.service` | The name of the application or service generating the log events.||
 | `datadog.hostname` | The name of the originating host of the log.||
-| `datadog.proxy.url` | Proxy endpoint when logs are not directly forwarded to Datadog.| `http-intake.logs.datadoghq.com` ||
+| `datadog.proxy.url` | Proxy endpoint when logs are not directly forwarded to Datadog.| `""` ||
 | `datadog.proxy.port` | Proxy port when logs are not directly forwarded to Datadog.| `443` ||
 | `datadog.retry.max` | The number of retries before the output plugin stops.| `5` ||
 | `datadog.retry.backoff_ms` | The time in milliseconds to wait following an error before a retry attempt is made.| `3000` ||

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ A REST call can be executed against one of the cluster instances, and the config
 | `datadog.tags` | Tags associated with your logs in a comma separated tag:value format.||
 | `datadog.service` | The name of the application or service generating the log events.||
 | `datadog.hostname` | The name of the originating host of the log.||
-| `datadog.proxy.url` | Proxy endpoint when logs are not directly forwarded to Datadog.| `""` ||
-| `datadog.proxy.port` | Proxy port when logs are not directly forwarded to Datadog.| `443` ||
+| `datadog.proxy.url` | Proxy endpoint when logs are not directly forwarded to Datadog.||
+| `datadog.proxy.port` | Proxy port when logs are not directly forwarded to Datadog.||
 | `datadog.retry.max` | The number of retries before the output plugin stops.| `5` ||
 | `datadog.retry.backoff_ms` | The time in milliseconds to wait following an error before a retry attempt is made.| `3000` ||
 

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,8 @@
 
                             <supportProviderName>Datadog</supportProviderName>
                             <supportSummary>
-                                Support is provided as best effort only. Please register any issues in the github project.
+                                Support in Github issues is provided as best effort. Support for Datadog users is
+                                given through Datadog's regular support channels.
                             </supportSummary>
                             <supportUrl>https://github.com/DataDog/datadog-kafka-connect-logs/issues</supportUrl>
                             <supportLogo>logos/datadog.png</supportLogo>

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -70,8 +72,6 @@ public class DatadogLogsApiWriter {
         URL url = new URL(
                 protocol
                         + config.url
-                        + ":"
-                        + config.port.toString()
                         + "/v1/input/"
                         + config.ddApiKey
         );
@@ -114,7 +114,13 @@ public class DatadogLogsApiWriter {
     }
 
     private void sendRequest(JsonObject content, URL url) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con;
+        if (!config.proxyURL.isEmpty()) {
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(config.proxyURL, config.proxyPort));
+            con = (HttpURLConnection) url.openConnection(proxy);
+        } else {
+            con = (HttpURLConnection) url.openConnection();
+        }
         con.setDoOutput(true);
         con.setRequestMethod("POST");
         con.setRequestProperty("Content-Type", "application/json");

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -29,12 +29,13 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
     public static final String RETRY_BACKOFF_MS = "datadog.retry.backoff_ms";
 
     // Respect limit documented at https://docs.datadoghq.com/api/?lang=bash#logs
-    public Integer ddMaxBatchLength = 500;
+    public final Integer ddMaxBatchLength;
+    public final Integer ddMaxBatchSize = 2560000;
     public final String ddSource = "kafka-connect";
 
     // Only for testing
-    public Boolean useSSL = true;
-    public String url = "http-intake.logs.datadoghq.com:443";
+    public final Boolean useSSL;
+    public final String url;
 
     public final String ddTags;
     public final String ddService;
@@ -57,6 +58,25 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         proxyPort = getInt(PROXY_PORT);
         retryMax = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);
+        useSSL = true;
+        url = "http-intake.logs.datadoghq.com:443";
+        ddMaxBatchLength = 500;
+        validateConfig();
+    }
+
+    public DatadogLogsSinkConnectorConfig(Boolean useSSL, String url, Integer ddMaxBatchLength, Map<String, String> props) {
+        super(baseConfigDef(), props);
+        ddTags = getTags(DD_TAGS);
+        ddService = getString(DD_SERVICE);
+        ddHostname = getString(DD_HOSTNAME);
+        ddApiKey = getPasswordValue(DD_API_KEY);
+        proxyURL = getString(PROXY_URL);
+        proxyPort = getInt(PROXY_PORT);
+        retryMax = getInt(MAX_RETRIES);
+        retryBackoffMs = getInt(RETRY_BACKOFF_MS);
+        this.useSSL = useSSL;
+        this.url = url;
+        this.ddMaxBatchLength = ddMaxBatchLength;
         validateConfig();
     }
 
@@ -139,7 +159,6 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
                 PROXY_PORT,
                 Type.INT,
                 null,
-                Range.between(1, 65535),
                 Importance.LOW,
                 "Proxy port when logs are not directly forwarded to Datadog.",
                 group,

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -59,7 +59,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         retryMax = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);
         useSSL = true;
-        url = "http-intake.logs.datadoghq.com:443";
+        url = "http-intake.logs.datad0g.com:443";
         ddMaxBatchLength = 500;
         validateConfig();
     }

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -128,7 +128,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         configDef.define(
                 PROXY_URL,
                 Type.STRING,
-                "",
+                null,
                 Importance.LOW,
                 "Proxy endpoint when logs are not directly forwarded to Datadog.",
                 group,
@@ -138,7 +138,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         ).define(
                 PROXY_PORT,
                 Type.INT,
-                443,
+                null,
                 Range.between(1, 65535),
                 Importance.LOW,
                 "Proxy port when logs are not directly forwarded to Datadog.",

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -23,8 +23,8 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
     public static final String DD_SERVICE = "datadog.service";
     public static final String DD_HOSTNAME = "datadog.hostname";
     public static final String DD_API_KEY = "datadog.api_key";
-    public static final String URL = "datadog.proxy.url";
-    public static final String PORT = "datadog.proxy.port";
+    public static final String PROXY_URL = "datadog.proxy.url";
+    public static final String PROXY_PORT = "datadog.proxy.port";
     public static final String MAX_RETRIES = "datadog.retry.max";
     public static final String RETRY_BACKOFF_MS = "datadog.retry.backoff_ms";
 
@@ -34,13 +34,14 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
     // Only for testing
     public Boolean useSSL = true;
+    public String url = "http-intake.logs.datadoghq.com:443";
 
     public final String ddTags;
     public final String ddService;
     public final String ddHostname;
     public final String ddApiKey;
-    public final String url;
-    public final Integer port;
+    public final String proxyURL;
+    public final Integer proxyPort;
     public final Integer retryMax;
     public final Integer retryBackoffMs;
 
@@ -52,8 +53,8 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         ddService = getString(DD_SERVICE);
         ddHostname = getString(DD_HOSTNAME);
         ddApiKey = getPasswordValue(DD_API_KEY);
-        url = getString(URL);
-        port = getInt(PORT);
+        proxyURL = getString(PROXY_URL);
+        proxyPort = getInt(PROXY_PORT);
         retryMax = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);
         validateConfig();
@@ -125,17 +126,17 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         final String group = "Datadog Proxy";
 
         configDef.define(
-                URL,
+                PROXY_URL,
                 Type.STRING,
-                "http-intake.logs.datadoghq.com",
+                "",
                 Importance.LOW,
                 "Proxy endpoint when logs are not directly forwarded to Datadog.",
                 group,
                 ++orderInGroup,
                 Width.LONG,
-                "URL"
+                "Proxy URL"
         ).define(
-                PORT,
+                PROXY_PORT,
                 Type.INT,
                 443,
                 Range.between(1, 65535),

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -75,7 +75,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
     private static void addMetadataConfigs(ConfigDef configDef) {
         int orderInGroup = 0;
-        final String group = "Metadata";
+        final String group = "Datadog Metadata";
 
         configDef.define(
                 DD_API_KEY,
@@ -122,7 +122,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
     private static void addProxyConfigs(ConfigDef configDef) {
         int orderInGroup = 0;
-        final String group = "Proxy";
+        final String group = "Datadog Proxy";
 
         configDef.define(
                 URL,
@@ -150,7 +150,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
     private static void addRetryConfigs(ConfigDef configDef) {
         int orderInGroup = 0;
-        final String group = "Retry";
+        final String group = "Datadog Retry";
 
         configDef.define(
                 MAX_RETRIES,

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
@@ -30,9 +30,7 @@ public class DatadogLogsApiWriterTest {
     public void setUp() throws Exception {
         records = new ArrayList<>();
         props = new HashMap<>();
-        props.put(DatadogLogsSinkConnectorConfig.URL, "localhost");
-        props.put(DatadogLogsSinkConnectorConfig.PORT, "1");
-        props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, RestHelper.apiKey);
+        props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, RestHelper.API_KEY);
         restHelper = new RestHelper();
         restHelper.start();
     }
@@ -47,6 +45,7 @@ public class DatadogLogsApiWriterTest {
     public void writer_givenConfigs_sendsPOSTToURL() throws IOException {
         config = new DatadogLogsSinkConnectorConfig(props);
         config.useSSL = false;
+        config.url = "localhost:1";
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -64,6 +63,7 @@ public class DatadogLogsApiWriterTest {
     public void writer_batchAtMax_shouldSendBatched() throws IOException {
         config = new DatadogLogsSinkConnectorConfig(props);
         config.useSSL = false;
+        config.url = "localhost:1";
         config.ddMaxBatchLength = 2;
         writer = new DatadogLogsApiWriter(config);
 
@@ -82,6 +82,7 @@ public class DatadogLogsApiWriterTest {
         config = new DatadogLogsSinkConnectorConfig(props);
         config.ddMaxBatchLength = 1;
         config.useSSL = false;
+        config.url = "localhost:1";
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -102,6 +103,7 @@ public class DatadogLogsApiWriterTest {
         config = new DatadogLogsSinkConnectorConfig(props);
         config.ddMaxBatchLength = 2;
         config.useSSL = false;
+        config.url = "localhost:1";
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic1", 0, null, "someKey", null, "someValue1", 0));
@@ -122,6 +124,7 @@ public class DatadogLogsApiWriterTest {
         props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "invalidAPIKey");
         config = new DatadogLogsSinkConnectorConfig(props);
         config.useSSL = false;
+        config.url = "localhost:1";
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -136,6 +139,7 @@ public class DatadogLogsApiWriterTest {
 
         config = new DatadogLogsSinkConnectorConfig(props);
         config.useSSL = false;
+        config.url = "localhost:1";
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -155,6 +159,7 @@ public class DatadogLogsApiWriterTest {
 
         config = new DatadogLogsSinkConnectorConfig(props);
         config.useSSL = false;
+        config.url = "localhost:1";
         config.ddMaxBatchLength = 1;
         writer = new DatadogLogsApiWriter(config);
 

--- a/src/test/java/com/datadoghq/connect/logs/sink/util/RestHelper.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/util/RestHelper.java
@@ -24,14 +24,14 @@ public class RestHelper extends HttpServlet {
 
     private Server server;
     private final List<RequestInfo> capturedRequests = new ArrayList<RequestInfo>();
-    public static final String apiKey = "test";
+    public static final String API_KEY = "test";
 
     public void start() throws Exception {
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
         ServletContextHandler handler = new ServletContextHandler();
         ServletHolder testServ = new ServletHolder("test", this);
-        handler.addServlet(testServ,"/v1/input/" + apiKey);
+        handler.addServlet(testServ,"/v1/input/" + API_KEY);
 
         server.setHandler(handler);
         connector.setPort(1);

--- a/test/datadog-avro-schema.json
+++ b/test/datadog-avro-schema.json
@@ -1,0 +1,15 @@
+{
+  "name": "DatadogAvroSchema",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "topics": "test-avro",
+    "datadog.api_key": "********",
+    "datadog.tags": "type:avro-schema",
+    "datadog.service": "kafka-avro",
+    "datadog.hostname": "berzan-test",
+    "value.converter.schema.registry.url": "http://localhost:8081"
+  }
+}

--- a/test/datadog-avro.json
+++ b/test/datadog-avro.json
@@ -1,0 +1,16 @@
+{
+  "name": "DatadogAvro",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "topics": "test-avro",
+    "datadog.api_key": "********",
+    "datadog.tags": "type:avro",
+    "datadog.service": "kafka-avro",
+    "datadog.hostname": "berzan-test",
+    "value.converter.schemas.enable": "false",
+    "value.converter.schema.registry.url": "http://localhost:8081"
+  }
+}

--- a/test/datadog-json-schema.json
+++ b/test/datadog-json-schema.json
@@ -1,0 +1,15 @@
+{
+  "name": "DatadogJSONSchema",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.json.JsonSchemaConverter",
+    "topics": "test-json-schema",
+    "datadog.api_key": "********",
+    "datadog.tags": "type:json-schema",
+    "datadog.service": "kafka-json",
+    "datadog.hostname": "berzan-test",
+    "value.converter.schema.registry.url": "http://localhost:8081"
+  }
+}

--- a/test/datadog-json.json
+++ b/test/datadog-json.json
@@ -1,0 +1,15 @@
+{
+  "name": "DatadogJSON",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "topics": "test-json",
+    "datadog.api_key": "**************",
+    "datadog.service": "kafka-json",
+    "datadog.hostname": "berzan-test",
+    "datadog.tags": "type:json",
+    "value.converter.schemas.enable": "false"
+  }
+}

--- a/test/datadog-perf.json
+++ b/test/datadog-perf.json
@@ -1,0 +1,16 @@
+{
+  "name": "DatadogPerf",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "10",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+    "topics": "perf-test",
+    "datadog.api_key": "**********",
+    "datadog.tags": "",
+    "datadog.service": "kafka-perf",
+    "datadog.hostname": "berzan-test",
+    "value.converter.schema.registry.url": "http://localhost:8081",
+    "value.converter.schemas.enable": "false"
+  }
+}

--- a/test/datadog-protobuf.json
+++ b/test/datadog-protobuf.json
@@ -1,0 +1,16 @@
+{
+  "name": "DatadogProtobuf",
+  "config": {
+    "connector.class": "com.datadoghq.connect.logs.DatadogLogsSinkConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.protobuf.ProtobufConverter",
+    "topics": "test-protobuf",
+    "datadog.api_key": "********",
+    "datadog.tags": "type:protobuf",
+    "datadog.service": "kafka-protobuf",
+    "datadog.hostname": "berzan-test",
+    "value.converter.schemas.enable": "false",
+    "value.converter.schema.registry.url": "http://localhost:8081"
+  }
+}

--- a/test/datagen-avro.json
+++ b/test/datagen-avro.json
@@ -1,0 +1,13 @@
+{
+  "name": "DatagenAvro",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "value.converter.schema.registry.url": "http://localhost:8081",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "kafka.topic": "test-avro",
+    "quickstart": "stock_trades",
+    "value.converter.schemas.enable": "false"
+  }
+}

--- a/test/datagen-json-schema.json
+++ b/test/datagen-json-schema.json
@@ -1,0 +1,13 @@
+{
+  "name": "DatagenJSONSchema",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.json.JsonSchemaConverter",
+    "datadog.tags": "type:json-schema",
+    "kafka.topic": "test-json-schema",
+    "quickstart": "users",
+    "value.converter.schema.registry.url": "http://localhost:8081"
+  }
+}

--- a/test/datagen-json.json
+++ b/test/datagen-json.json
@@ -1,0 +1,12 @@
+{
+  "name": "DatagenJSON",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "kafka.topic": "test-json",
+    "value.converter.schemas.enable": "false",
+    "quickstart": "users"
+  }
+}

--- a/test/datagen-protobuf.json
+++ b/test/datagen-protobuf.json
@@ -1,0 +1,13 @@
+{
+  "name": "DatagenProtobuf",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "value.converter.schema.registry.url": "http://localhost:8081",
+    "tasks.max": "1",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "io.confluent.connect.protobuf.ProtobufConverter",
+    "kafka.topic": "test-protobuf",
+    "quickstart": "inventory",
+    "value.converter.schemas.enable": "false"
+  }
+}


### PR DESCRIPTION
Adds logic to batch up collected records per topic and tag them for easier viewing in the Datadog Dashboard.