### PR TITLE
Initialize jsonconverter once and update batchmap

### DIFF
--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -24,10 +24,14 @@ import javax.ws.rs.core.Response;
 public class DatadogLogsApiWriter {
     private final DatadogLogsSinkConnectorConfig config;
     private static final Logger log = LoggerFactory.getLogger(DatadogLogsApiWriter.class);
-    private Map<String, List<SinkRecord>> batches = new HashMap<>();
+    private final Map<String, List<SinkRecord>> batches;
+    private final JsonConverter jsonConverter;
 
     public DatadogLogsApiWriter(DatadogLogsSinkConnectorConfig config) {
         this.config = config;
+        this.batches = new HashMap<>();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
     }
 
     /**
@@ -102,8 +106,6 @@ public class DatadogLogsApiWriter {
     }
 
     private JsonElement recordToJSON(SinkRecord record) {
-        JsonConverter jsonConverter = new JsonConverter();
-        jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
 
         byte[] rawJSONPayload = jsonConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
         String jsonPayload = new String(rawJSONPayload, StandardCharsets.UTF_8);

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -18,14 +18,13 @@ import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.GZIPOutputStream;
 import javax.ws.rs.core.Response;
 
 public class DatadogLogsApiWriter {
     private final DatadogLogsSinkConnectorConfig config;
     private static final Logger log = LoggerFactory.getLogger(DatadogLogsApiWriter.class);
-    private Map<String, List<SinkRecord>> batches = new ConcurrentHashMap<>();
+    private Map<String, List<SinkRecord>> batches = new HashMap<>();
 
     public DatadogLogsApiWriter(DatadogLogsSinkConnectorConfig config) {
         this.config = config;
@@ -45,6 +44,7 @@ public class DatadogLogsApiWriter {
             }
             if (batches.get(record.topic()).size() >= config.ddMaxBatchLength) {
                 sendBatch(record.topic());
+                batches.remove(record.topic());
             }
         }
 
@@ -57,6 +57,8 @@ public class DatadogLogsApiWriter {
         for(Map.Entry<String,List<SinkRecord>> entry: batches.entrySet()) {
             sendBatch(entry.getKey());
         }
+
+        batches.clear();
     }
 
     private void sendBatch(String topic) throws IOException {
@@ -75,7 +77,6 @@ public class DatadogLogsApiWriter {
                         + config.ddApiKey
         );
 
-        batches.remove(topic);
         sendRequest(content, url);
     }
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -10,7 +10,6 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Width;
-import org.apache.kafka.common.config.ConfigDef.Range;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 


### PR DESCRIPTION
### What does this PR do?

Changes JSONConverter to only initialize it once, and change the batchmap to a normal Hashmap.

### Motivation

JSONConverter would spam INFO logs with each `put`.