### PR TITLE
Only open one http connection per task

### DIFF
--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
@@ -115,7 +115,6 @@ public class DatadogLogsApiWriterTest {
         Assert.assertEquals("[{\"message\":\"someValue1\",\"ddsource\":\"kafka-connect\",\"ddtags\":\"topic:someTopic1\"}]", request2.getBody());
         Assert.assertEquals("[{\"message\":\"someValue2\",\"ddsource\":\"kafka-connect\",\"ddtags\":\"topic:someTopic2\"}]", request1.getBody());
     }
-    **/
 
     @Test(expected = IOException.class)
     public void writer_givenError_shouldThrowException() throws IOException {

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkTaskTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkTaskTest.java
@@ -13,12 +13,13 @@ import org.easymock.EasyMockSupport;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
 public class DatadogLogsSinkTaskTest extends EasyMockSupport {
@@ -41,7 +42,7 @@ public class DatadogLogsSinkTaskTest extends EasyMockSupport {
         final DatadogLogsApiWriter mockWriter = createMock(DatadogLogsApiWriter.class);
         SinkTaskContext ctx = createMock(SinkTaskContext.class);
 
-        mockWriter.write(records);
+        mockWriter.write(eq(records), anyObject(HttpURLConnection.class));
         expectLastCall().andThrow(new IOException()).times(1 + maxRetries);
 
         ctx.timeout(retryBackoffMs);


### PR DESCRIPTION
### What does this PR do?

Changes the logic so that only one connection is kept open per task instead of one per batch.

### Motivation

Reduce open and closing of network connections.

### Additional Notes

Closes #9 