### PR TITLE
Add DD_URL parameter to configure the logs url endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+# 1.0.4 / 2022-01-07
+
+### Changes
+* Add datadog url endpoint configurable from parameters
+
 # 1.0.3 / 2021-12-18
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A REST call can be executed against one of the cluster instances, and the config
 #### General Optional Parameters
 | Name              | Description                | Default Value  |
 |--------           |----------------------------|-----------------------|
+| `datadog.url` | Datadog url endpoint where your logs will be sent| `http-intake.logs.datadoghq.com:443` ||
 | `datadog.tags` | Tags associated with your logs in a comma separated tag:value format.||
 | `datadog.service` | The name of the application or service generating the log events.||
 | `datadog.hostname` | The name of the originating host of the log.||

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
+    public static final String DD_URL = "datadog.url";
     public static final String DD_TAGS = "datadog.tags";
     public static final String DD_SERVICE = "datadog.service";
     public static final String DD_HOSTNAME = "datadog.hostname";
@@ -57,7 +58,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         retryMax = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);
         useSSL = true;
-        url = "http-intake.logs.datadoghq.com:443";
+        url = getString(DD_URL);
         ddMaxBatchLength = 500;
         validateConfig();
     }
@@ -82,6 +83,9 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         if (getPasswordValue(DD_API_KEY) == null) {
             throw new ConfigException("API Key must not be empty.");
         }
+        if (getString(DD_URL) == null) {
+            throw new ConfigException("Url must not be empty.");
+        }
     }
 
     private static ConfigDef baseConfigDef() {
@@ -97,6 +101,16 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         final String group = "Datadog Metadata";
 
         configDef.define(
+                DD_URL,
+                Type.STRING,
+                "http-intake.logs.datadoghq.com:443",
+                Importance.HIGH,
+                "The URL endpoint where logs will be send",
+                group,
+                ++orderInGroup,
+                Width.LONG,
+                "Datadog logs endpoint"
+        ).define(
                 DD_API_KEY,
                 Type.PASSWORD,
                 ConfigDef.NO_DEFAULT_VALUE,

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
@@ -34,4 +34,19 @@ public class DatadogLogsSinkConnectorConfigTest {
 
         assertEquals("test1,test2,test3", config.ddTags);
     }
+
+    @Test
+    public void getUrl_givenValidProps_shouldReturnString() {
+        props = new HashMap<>();
+        props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "123");
+        DatadogLogsSinkConnectorConfig config = new DatadogLogsSinkConnectorConfig(props);
+        
+        props.put(DatadogLogsSinkConnectorConfig.DD_URL, "example.com");
+        DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
+
+
+        assertEquals("http-intake.logs.datadoghq.com:443", config.url);
+        assertEquals("example.com", customConfig.url);
+
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Add DD_URL parameter to be able to configure the URL endpoint, instead of a hardcoded one.

### Motivation

What inspired you to submit this pull request?

the need to use this Kafka connector against the datadog EU endpoint

### Additional Notes

Anything else we should know when reviewing?

https://github.com/DataDog/datadog-kafka-connect-logs/issues/22