### PR TITLE
Add datadog.site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Changes
 * Add datadog url endpoint configurable from parameters
+* Add datadog site configurable from parameters
 
 # 1.0.3 / 2021-12-18
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ A REST call can be executed against one of the cluster instances, and the config
 #### General Optional Parameters
 | Name              | Description                | Default Value  |
 |--------           |----------------------------|-----------------------|
-| `datadog.url` | Datadog url endpoint where your logs will be sent| `http-intake.logs.datadoghq.com:443` ||
+| `datadog.url` | Datadog URL endpoint where your logs will be sent. `datadog.url` takes precedence over `datadog.site`. Example: `http-intake.logs.datadoghq.com:443` ||
+| `datadog.site` | The site of the Datadog intake to send Agent data to (For example 'datadoghq.eu' to send data to the EU site) ||
 | `datadog.tags` | Tags associated with your logs in a comma separated tag:value format.||
 | `datadog.service` | The name of the application or service generating the log events.||
 | `datadog.hostname` | The name of the originating host of the log.||

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ A REST call can be executed against one of the cluster instances, and the config
 #### General Optional Parameters
 | Name              | Description                | Default Value  |
 |--------           |----------------------------|-----------------------|
-| `datadog.url` | Datadog URL endpoint where your logs will be sent. `datadog.url` takes precedence over `datadog.site`. Example: `http-intake.logs.datadoghq.com:443` ||
-| `datadog.site` | The site of the Datadog intake to send Agent data to (For example 'datadoghq.eu' to send data to the EU site) ||
+| `datadog.site` | The site of the Datadog intake to send logs to (for example 'datadoghq.eu' to send data to the EU site) | `datadoghq.com` |
+| `datadog.url` | Custom Datadog URL endpoint where your logs will be sent. `datadog.url` takes precedence over `datadog.site`. Example: `http-intake.logs.datadoghq.com:443` ||
 | `datadog.tags` | Tags associated with your logs in a comma separated tag:value format.||
 | `datadog.service` | The name of the application or service generating the log events.||
 | `datadog.hostname` | The name of the originating host of the log.||

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -76,7 +76,7 @@ public class DatadogLogsApiWriter {
 
         URL url = new URL(
                 protocol
-                        + config.url
+                        + config.ddUrl
                         + "/v1/input/"
                         + config.ddApiKey
         );

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -72,14 +72,7 @@ public class DatadogLogsApiWriter {
             return;
         }
 
-        String protocol = config.useSSL ? "https://" : "http://";
-
-        URL url = new URL(
-                protocol
-                        + config.ddUrl
-                        + "/v1/input/"
-                        + config.ddApiKey
-        );
+        URL url = config.getURL();
 
         sendRequest(content, url);
     }

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -27,6 +27,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
     public static final String PROXY_PORT = "datadog.proxy.port";
     public static final String MAX_RETRIES = "datadog.retry.max";
     public static final String RETRY_BACKOFF_MS = "datadog.retry.backoff_ms";
+    public static final String DEFAULT_DD_URL = "http-intake.logs.datadoghq.com:443";
 
     // Respect limit documented at https://docs.datadoghq.com/api/?lang=bash#logs
     public final Integer ddMaxBatchLength;
@@ -34,8 +35,8 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
 
     // Only for testing
     public final Boolean useSSL;
-    public final String url;
 
+    public final String ddUrl;
     public final String ddTags;
     public final String ddService;
     public final String ddHostname;
@@ -48,22 +49,10 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
     public DatadogLogsSinkConnectorConfig(Map<String, String> props) {
-        super(baseConfigDef(), props);
-        ddTags = getTags(DD_TAGS);
-        ddService = getString(DD_SERVICE);
-        ddHostname = getString(DD_HOSTNAME);
-        ddApiKey = getPasswordValue(DD_API_KEY);
-        proxyURL = getString(PROXY_URL);
-        proxyPort = getInt(PROXY_PORT);
-        retryMax = getInt(MAX_RETRIES);
-        retryBackoffMs = getInt(RETRY_BACKOFF_MS);
-        useSSL = true;
-        url = getString(DD_URL);
-        ddMaxBatchLength = 500;
-        validateConfig();
+        this(true, 500, props);
     }
 
-    public DatadogLogsSinkConnectorConfig(Boolean useSSL, String url, Integer ddMaxBatchLength, Map<String, String> props) {
+    public DatadogLogsSinkConnectorConfig(Boolean useSSL, Integer ddMaxBatchLength, Map<String, String> props) {
         super(baseConfigDef(), props);
         ddTags = getTags(DD_TAGS);
         ddService = getString(DD_SERVICE);
@@ -74,7 +63,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         retryMax = getInt(MAX_RETRIES);
         retryBackoffMs = getInt(RETRY_BACKOFF_MS);
         this.useSSL = useSSL;
-        this.url = url;
+        this.ddUrl = getString(DD_URL);
         this.ddMaxBatchLength = ddMaxBatchLength;
         validateConfig();
     }
@@ -103,7 +92,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
         configDef.define(
                 DD_URL,
                 Type.STRING,
-                "http-intake.logs.datadoghq.com:443",
+                DEFAULT_DD_URL,
                 Importance.HIGH,
                 "The URL endpoint where logs will be send",
                 group,

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
@@ -31,6 +31,7 @@ public class DatadogLogsApiWriterTest {
         records = new ArrayList<>();
         props = new HashMap<>();
         props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, RestHelper.API_KEY);
+        props.put(DatadogLogsSinkConnectorConfig.DD_URL, "localhost:8080");
         restHelper = new RestHelper();
         restHelper.start();
     }
@@ -43,7 +44,7 @@ public class DatadogLogsApiWriterTest {
 
     @Test
     public void writer_givenConfigs_sendsPOSTToURL() throws IOException {
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 500, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 500, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -59,7 +60,7 @@ public class DatadogLogsApiWriterTest {
 
     @Test
     public void writer_batchAtMax_shouldSendBatched() throws IOException {
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 2, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 2, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -74,7 +75,7 @@ public class DatadogLogsApiWriterTest {
 
     @Test
     public void writer_batchAboveMax_shouldSendSeparate() throws IOException {
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 1, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 1, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -92,7 +93,7 @@ public class DatadogLogsApiWriterTest {
 
     @Test
     public void writer_readingMultipleTopics_shouldBatchSeparate() throws IOException {
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 2, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 2, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic1", 0, null, "someKey", null, "someValue1", 0));
@@ -111,7 +112,7 @@ public class DatadogLogsApiWriterTest {
     @Test(expected = IOException.class)
     public void writer_givenError_shouldThrowException() throws IOException {
         props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "invalidAPIKey");
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 500, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 500, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));
@@ -124,7 +125,7 @@ public class DatadogLogsApiWriterTest {
         props.put(DatadogLogsSinkConnectorConfig.DD_HOSTNAME, "test-host");
         props.put(DatadogLogsSinkConnectorConfig.DD_SERVICE, "test-service");
 
-        config = new DatadogLogsSinkConnectorConfig(false, "localhost:8080", 500, props);
+        config = new DatadogLogsSinkConnectorConfig(false, 500, props);
         writer = new DatadogLogsApiWriter(config);
 
         records.add(new SinkRecord("someTopic", 0, null, "someKey", null, "someValue1", 0));

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
@@ -8,6 +8,7 @@ package com.datadoghq.connect.logs.sink;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
 
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,16 +37,31 @@ public class DatadogLogsSinkConnectorConfigTest {
     }
 
     @Test
-    public void getUrl_givenValidProps_shouldReturnString() {
+    public void getURL_default() throws MalformedURLException {
         props = new HashMap<>();
         props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "123");
-        DatadogLogsSinkConnectorConfig config = new DatadogLogsSinkConnectorConfig(props);
-        
+        DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
+
+        assertEquals("https://http-intake.logs.datadoghq.com:443/v1/input/123", customConfig.getURL().toString());
+    }
+
+    @Test
+    public void getURL_ddURL() throws MalformedURLException {
+        props = new HashMap<>();
+        props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "123");
         props.put(DatadogLogsSinkConnectorConfig.DD_URL, "example.com");
         DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
 
+        assertEquals("https://example.com/v1/input/123", customConfig.getURL().toString());
+    }
 
-        assertEquals(DatadogLogsSinkConnectorConfig.DEFAULT_DD_URL, config.ddUrl);
-        assertEquals("example.com", customConfig.ddUrl);
+    @Test
+    public void getURL_ddSite() throws MalformedURLException {
+        props = new HashMap<>();
+        props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "123");
+        props.put(DatadogLogsSinkConnectorConfig.DD_SITE, "SITE");
+        DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
+
+        assertEquals("https://http-intake.logs.SITE:443/v1/input/123", customConfig.getURL().toString());
     }
 }

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
@@ -45,8 +45,7 @@ public class DatadogLogsSinkConnectorConfigTest {
         DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
 
 
-        assertEquals("http-intake.logs.datadoghq.com:443", config.url);
-        assertEquals("example.com", customConfig.url);
-
+        assertEquals(DatadogLogsSinkConnectorConfig.DEFAULT_DD_URL, config.ddUrl);
+        assertEquals("example.com", customConfig.ddUrl);
     }
 }


### PR DESCRIPTION
### What does this PR do?

Add `datadog.site` to configure the site of the Datadog intake to send Agent data to.

### Motivation

It is a short way to configure `datadog.url`.