### PR TITLE
Log api v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-# 1.0.4 / 2022-01-14
+# 1.1.0 / in development
 
 ### Changes
 * Add datadog url endpoint configurable from parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Changelog
 =========
 
-# 1.0.4 / 2022-01-07
+# 1.0.4 / 2022-01-14
 
 ### Changes
 * Add datadog url endpoint configurable from parameters
 * Add datadog site configurable from parameters
+* Use API V2 endpoint
 
 # 1.0.3 / 2021-12-18
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 

--- a/src/main/java/com/datadoghq/connect/logs/DatadogLogsSinkConnector.java
+++ b/src/main/java/com/datadoghq/connect/logs/DatadogLogsSinkConnector.java
@@ -7,7 +7,7 @@ package com.datadoghq.connect.logs;
 
 import com.datadoghq.connect.logs.sink.DatadogLogsSinkConnectorConfig;
 import com.datadoghq.connect.logs.sink.DatadogLogsSinkTask;
-import com.datadoghq.connect.logs.util.Version;
+import com.datadoghq.connect.logs.util.Project;
 
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
@@ -59,7 +59,7 @@ public class DatadogLogsSinkConnector extends SinkConnector {
 
     @Override
     public String version() {
-        return Version.getVersion();
+        return Project.getVersion();
     }
 
     @Override

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -174,9 +174,7 @@ public class DatadogLogsApiWriter {
         con.setRequestProperty("Content-Type", "application/json");
         con.setRequestProperty("Content-Encoding", "gzip");
         con.setRequestProperty("DD-API-KEY", config.ddApiKey);
-
-        Package p = getClass().getPackage();
-        con.setRequestProperty("DD-EVP-ORIGIN", p.getName());
+        con.setRequestProperty("DD-EVP-ORIGIN", Project.getName());
         con.setRequestProperty("DD-EVP-ORIGIN-VERSION", Project.getVersion());
     }
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -5,6 +5,7 @@ This product includes software developed at Datadog (https://www.datadoghq.com/)
 
 package com.datadoghq.connect.logs.sink;
 
+import com.datadoghq.connect.logs.util.Version;
 import com.google.gson.*;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -139,8 +140,7 @@ public class DatadogLogsApiWriter {
         }
         con.setDoOutput(true);
         con.setRequestMethod("POST");
-        con.setRequestProperty("Content-Type", "application/json");
-        con.setRequestProperty("Content-Encoding", "gzip");
+        setRequestProperties(con);
 
         DataOutputStream output = new DataOutputStream(con.getOutputStream());
         output.write(compressedPayload);
@@ -168,6 +168,16 @@ public class DatadogLogsApiWriter {
 
         log.debug("Response content: " + response);
         con.disconnect();
+    }
+
+    private void setRequestProperties(HttpURLConnection con) {
+        con.setRequestProperty("Content-Type", "application/json");
+        con.setRequestProperty("Content-Encoding", "gzip");
+        con.setRequestProperty("DD-API-KEY", config.ddApiKey);
+
+        Package p = getClass().getPackage();
+        con.setRequestProperty("DD-EVP-ORIGIN", p.getName());
+        con.setRequestProperty("DD-EVP-ORIGIN-VERSION", Version.getVersion());
     }
 
     private byte[] compress(String str) throws IOException {

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -5,7 +5,7 @@ This product includes software developed at Datadog (https://www.datadoghq.com/)
 
 package com.datadoghq.connect.logs.sink;
 
-import com.datadoghq.connect.logs.util.Version;
+import com.datadoghq.connect.logs.util.Project;
 import com.google.gson.*;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -177,7 +177,7 @@ public class DatadogLogsApiWriter {
 
         Package p = getClass().getPackage();
         con.setRequestProperty("DD-EVP-ORIGIN", p.getName());
-        con.setRequestProperty("DD-EVP-ORIGIN-VERSION", Version.getVersion());
+        con.setRequestProperty("DD-EVP-ORIGIN-VERSION", Project.getVersion());
     }
 
     private byte[] compress(String str) throws IOException {

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -150,7 +150,11 @@ public class DatadogLogsApiWriter {
         // get response
         int status = con.getResponseCode();
         if (Response.Status.Family.familyOf(status) != Response.Status.Family.SUCCESSFUL) {
-            String error = getOutput(con.getErrorStream());
+            InputStream stream = con.getErrorStream();
+            String error = "";
+            if (stream != null ) {
+                error = getOutput(stream);
+            }
             con.disconnect();
             throw new IOException("HTTP Response code: " + status
                     + ", " + con.getResponseMessage() + ", " + error

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfig.java
@@ -86,12 +86,7 @@ public class DatadogLogsSinkConnectorConfig extends AbstractConfig {
             domain = String.format(DD_URL_FORMAT_FROM_SITE, ddSite);
         }
 
-        return new URL(
-                protocol
-                        + domain
-                        + "/v1/input/"
-                        + ddApiKey
-        );
+        return new URL(protocol + domain + "/api/v2/logs");
     }
     private void validateConfig() {
         if (getPasswordValue(DD_API_KEY) == null) {

--- a/src/main/java/com/datadoghq/connect/logs/util/Project.java
+++ b/src/main/java/com/datadoghq/connect/logs/util/Project.java
@@ -15,12 +15,14 @@ public class Project {
     private static final Logger log = LoggerFactory.getLogger(Project.class);
     private static final String PATH = "/datadog-kafka-connect-logs.properties";
     private static String version = "unknown";
+    private static String name = "unknown";
 
     static {
         try (InputStream stream = Project.class.getResourceAsStream(PATH)) {
             Properties properties = new Properties();
             properties.load(stream);
             version = properties.getProperty("version", version).trim();
+            name = properties.getProperty("name", name).trim();
         } catch (Exception e) {
             log.warn("Error while loading version: ", e);
         }
@@ -28,5 +30,9 @@ public class Project {
 
     public static String getVersion() {
         return version;
+    }
+
+    public static String getName() {
+        return name;
     }
 }

--- a/src/main/java/com/datadoghq/connect/logs/util/Project.java
+++ b/src/main/java/com/datadoghq/connect/logs/util/Project.java
@@ -11,13 +11,13 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.util.Properties;
 
-public class Version {
-    private static final Logger log = LoggerFactory.getLogger(Version.class);
+public class Project {
+    private static final Logger log = LoggerFactory.getLogger(Project.class);
     private static final String PATH = "/datadog-kafka-connect-logs.properties";
     private static String version = "unknown";
 
     static {
-        try (InputStream stream = Version.class.getResourceAsStream(PATH)) {
+        try (InputStream stream = Project.class.getResourceAsStream(PATH)) {
             Properties properties = new Properties();
             properties.load(stream);
             version = properties.getProperty("version", version).trim();

--- a/src/main/resources/datadog-kafka-connect-logs.properties
+++ b/src/main/resources/datadog-kafka-connect-logs.properties
@@ -1,1 +1,2 @@
 version=${project.version}
+name=${project.name}

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
@@ -58,7 +58,7 @@ public class DatadogLogsApiWriterTest {
         Assert.assertTrue(request.getHeaders().contains("Content-Type:application/json"));
         Assert.assertTrue(request.getHeaders().contains("Content-Encoding:gzip"));
         Assert.assertTrue(request.getHeaders().contains("DD-API-KEY:" + apiKey));
-        Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN:com.datadoghq.connect.logs.sink"));
+        Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN:datadog-kafka-connect-logs"));
         Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN-VERSION:" + Project.getVersion()));
     }
 

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriterTest.java
@@ -7,7 +7,7 @@ package com.datadoghq.connect.logs.sink;
 
 import com.datadoghq.connect.logs.sink.util.RequestInfo;
 import com.datadoghq.connect.logs.sink.util.RestHelper;
-import com.datadoghq.connect.logs.util.Version;
+import com.datadoghq.connect.logs.util.Project;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
@@ -59,7 +59,7 @@ public class DatadogLogsApiWriterTest {
         Assert.assertTrue(request.getHeaders().contains("Content-Encoding:gzip"));
         Assert.assertTrue(request.getHeaders().contains("DD-API-KEY:" + apiKey));
         Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN:com.datadoghq.connect.logs.sink"));
-        Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN-VERSION:" + Version.getVersion()));
+        Assert.assertTrue(request.getHeaders().contains("DD-EVP-ORIGIN-VERSION:" + Project.getVersion()));
     }
 
     @Test

--- a/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkConnectorConfigTest.java
@@ -42,7 +42,7 @@ public class DatadogLogsSinkConnectorConfigTest {
         props.put(DatadogLogsSinkConnectorConfig.DD_API_KEY, "123");
         DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
 
-        assertEquals("https://http-intake.logs.datadoghq.com:443/v1/input/123", customConfig.getURL().toString());
+        assertEquals("https://http-intake.logs.datadoghq.com:443/api/v2/logs", customConfig.getURL().toString());
     }
 
     @Test
@@ -52,7 +52,7 @@ public class DatadogLogsSinkConnectorConfigTest {
         props.put(DatadogLogsSinkConnectorConfig.DD_URL, "example.com");
         DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
 
-        assertEquals("https://example.com/v1/input/123", customConfig.getURL().toString());
+        assertEquals("https://example.com/api/v2/logs", customConfig.getURL().toString());
     }
 
     @Test
@@ -62,6 +62,6 @@ public class DatadogLogsSinkConnectorConfigTest {
         props.put(DatadogLogsSinkConnectorConfig.DD_SITE, "SITE");
         DatadogLogsSinkConnectorConfig customConfig = new DatadogLogsSinkConnectorConfig(props);
 
-        assertEquals("https://http-intake.logs.SITE:443/v1/input/123", customConfig.getURL().toString());
+        assertEquals("https://http-intake.logs.SITE:443/api/v2/logs", customConfig.getURL().toString());
     }
 }

--- a/src/test/java/com/datadoghq/connect/logs/sink/util/RestHelper.java
+++ b/src/test/java/com/datadoghq/connect/logs/sink/util/RestHelper.java
@@ -24,14 +24,14 @@ public class RestHelper extends HttpServlet {
 
     private Server server;
     private final List<RequestInfo> capturedRequests = new ArrayList<RequestInfo>();
-    public static final String API_KEY = "test";
+    private int statusCode = HttpServletResponse.SC_OK;
 
     public void start() throws Exception {
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
         ServletContextHandler handler = new ServletContextHandler();
         ServletHolder testServ = new ServletHolder("test", this);
-        handler.addServlet(testServ,"/v1/input/" + API_KEY);
+        handler.addServlet(testServ,"/api/v2/logs");
 
         server.setHandler(handler);
         connector.setPort(8080);
@@ -44,12 +44,15 @@ public class RestHelper extends HttpServlet {
         server.stop();
     }
 
+    public void setHttpStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         capturedRequests.add(getRequestInfo(request));
 
         response.setContentType("application/json");
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.getWriter().println("{ \"status\": \"ok\"}");
+        response.setStatus(statusCode);
     }
 
     private RequestInfo getRequestInfo(HttpServletRequest request) throws IOException {


### PR DESCRIPTION
### What does this PR do?

Use API V2 endpoint (`/api/v2/logs`)
API key is not sent as a part of the URL but as the header `DD-API-KEY`.
