### PR TITLE
Fix a CVE in GSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+# 1.1.1 / 2022-06-07
+
+### Changes
+* Fix CVE-2022-25647 by upgrading the version of `com.google.code.gson` to `2.8.9`.
+
 # 1.1.0 / 2022-01-17
 
 ### Changes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 
@@ -47,7 +47,7 @@
         <jetty.version>9.4.41.v20210516</jetty.version>
         <junit.version>4.13.1</junit.version>
         <java.version>1.8</java.version>
-        <gson.version>2.8.6</gson.version>
+        <gson.version>2.8.9</gson.version>
         <slf4j.version>1.7.32</slf4j.version>
 
         <kafka-connect-maven-plugin.version>0.11.3</kafka-connect-maven-plugin.version>


### PR DESCRIPTION
### What does this PR do?

FIX [CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) by upgrading the version of `com.google.code.gson` to `2.8.9`

### Motivation

What inspired you to submit this pull request?

https://github.com/DataDog/datadog-kafka-connect-logs/security/dependabot/2