### PR TITLE
Updated CircleCI maven image (previous img deprecated)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
+---
 version: 2.1
 
 orbs:
-  maven: circleci/maven@0.0.12
+  maven: circleci/maven@1.4.1
 
 workflows:
   maven_test:


### PR DESCRIPTION
### What does this PR do?

Updates the Maven image used by CircleCI.

### Motivation

The CircleCI jobs were using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

### Additional Notes

None.
