### PR TITLE
Adding multiple JDKs to build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,50 @@
+---
 version: 2.1
 
-orbs:
-  maven: circleci/maven@0.0.12
+build_steps: &build_steps
+  steps:
+    - checkout
+    - setup_remote_docker
+    - run: mvn test
+
+jobs:
+  test_openjdk8:
+    docker:
+      - image: cimg/openjdk:8.0
+    <<: *build_steps
+  test_openjdk11:
+    docker:
+      - image: cimg/openjdk:11.0
+    <<: *build_steps
+  test_openjdk15:
+    docker:
+      - image: cimg/openjdk:15.0
+    <<: *build_steps
+  test_openjdk17:
+    docker:
+      - image: cimg/openjdk:17.0
+    <<: *build_steps
+  test_openjdk18:
+    docker:
+      - image: cimg/openjdk:18.0
+    <<: *build_steps
+  test_openjdk19:
+    docker:
+      - image: cimg/openjdk:19.0
+    <<: *build_steps
+  test_openjdk20:
+    docker:
+      - image: cimg/openjdk:20.0
+    <<: *build_steps
 
 workflows:
-  maven_test:
+  workflow:
     jobs:
-      - maven/test
+      - test_openjdk8
+      - test_openjdk11
+      - test_openjdk15
+#   Waiting for Easymock 5.2.0 to be released
+#      - test_openjdk17
+#      - test_openjdk18
+#      - test_openjdk19
+#      - test_openjdk19


### PR DESCRIPTION
### What does this PR do?

Updates the CircleCI images to use new Java images instead + add a matrix of JVMs to test.

### Motivation

The CircleCI jobs were using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

### Additional Notes

None.
