### PR TITLE
[AGENT-11265] Removed call to disconnect on HttpURLConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 # 1.1.2 / TBC
 
 ### Changes
-* Removed call to `disconnect` on `HttpURLConnection` to encourage connection resuse.
+* Removed call to `disconnect` on `HttpURLConnection` to encourage connection reuse.
 
 # 1.1.1 / 2022-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+# 1.1.2 / TBC
+
+### Changes
+* Removed call to `disconnect` on `HttpURLConnection` to encourage connection resuse.
+
 # 1.1.1 / 2022-06-07
 
 ### Changes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -167,7 +167,6 @@ public class DatadogLogsApiWriter {
         String response = getOutput(con.getInputStream());
 
         log.debug("Response content: " + response);
-        con.disconnect();
     }
 
     private void setRequestProperties(HttpURLConnection con) {


### PR DESCRIPTION
### What does this PR do?

This removes a call to `disconnect` on the `HttpURLConnection` when the request was successful.

### Motivation

This should in theory enogucarge connection reuse.

### Additional Notes

None.