### PR TITLE
Allow mocking of java.lang for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.confluent</groupId>


### PR DESCRIPTION
Otherwise you run into:

```
-------------------------------------------------------------------------------
Test set: com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.138 s <<< FAILURE! - in com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest
com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest.putTask_onRetry_shouldThrowExceptions  Time elapsed: 0.085 s  <<< ERROR!
java.lang.ExceptionInInitializerError
        at com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest.putTask_onRetry_shouldThrowExceptions(DatadogLogsSinkTaskTest.java:41)
Caused by: org.easymock.cglib.core.CodeGenerationException: java.lang.reflect.InaccessibleObjectException-->Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @4d5804c6
        at com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest.putTask_onRetry_shouldThrowExceptions(DatadogLogsSinkTaskTest.java:41)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @4d5804c6
        at com.datadoghq.connect.logs.sink.DatadogLogsSinkTaskTest.putTask_onRetry_shouldThrowExceptions(DatadogLogsSinkTaskTest.java:41)
```

On newer versions of Java (>= 17?).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
