### PR TITLE
Encode decimal values as numeric rather than base64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -32,7 +32,12 @@ public class DatadogLogsApiWriter {
         this.config = config;
         this.batches = new HashMap<>();
         this.jsonConverter = new JsonConverter();
-        jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
+
+        Map<String,String> jsonConverterConfig = new HashMap<String,String>();
+        jsonConverterConfig.put("schemas.enable", "false");
+        jsonConverterConfig.put("decimal.format", "NUMERIC");
+
+        jsonConverter.configure(jsonConverterConfig, false);
     }
 
     /**


### PR DESCRIPTION
Currently incoming `BigDecimal` values (e.g. from avro decoding) are
encoded as base64 strings (the default) by the JsonConverter. Instead,
it seems to make more sense to encode them as numeric values when
publishing to Datadog.

I considered making this configurable, but it seems unlikely that users
would want the current behavior since it makes the data much less
scruitable in Datadog. If we find this not to be the case (through an
issue report) we can add a configuration option later. As it stands,
I think it is a bug.

Fixes: https://github.com/DataDog/datadog-kafka-connect-logs/issues/27

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
