### PR TITLE
Remove javax dependency to maintain kafka version interoperability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -17,7 +17,6 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -191,7 +190,7 @@ public class DatadogLogsApiWriter {
 
         // get response
         int status = con.getResponseCode();
-        if (Response.Status.Family.familyOf(status) != Response.Status.Family.SUCCESSFUL) {
+        if (!isSuccessfulHttpStatus(status)) {
             InputStream stream = con.getErrorStream();
             String error = "";
             if (stream != null) {
@@ -204,6 +203,16 @@ public class DatadogLogsApiWriter {
         }
 
         log.trace("Received HTTP response {} {} with body {}", status, con.getResponseMessage(), getOutput(con.getInputStream()));
+    }
+
+    /**
+     * Check if the HTTP status code indicates success (2xx range)
+     * 
+     * @param statusCode HTTP status code to check
+     * @return true if status code is in the 2xx range (200-299)
+     */
+    private boolean isSuccessfulHttpStatus(int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
     }
 
     private void setRequestProperties(HttpURLConnection con) {


### PR DESCRIPTION
### What does this PR do?

 Confluent Platform version 8.0.0 removes the deprecated javax package in favor of the equivalent functionality found in jakarta, breaking our connector's support for this version. However, we only utilize the javax package in non-test code to verify the response code of a http request is 2XX. This does not require either package.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?