### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,3 @@
 # and another team can own the rest of the directory.
 
 *           @Datadog/agent-log-pipelines
-
-# Documentation
-*.md        @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?

Removes Docs as CODEOWNERS from the repo.

### Motivation

As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

### Additional Notes

Anything else we should know when reviewing?