### PR TITLE
AGNTLOG-200: replace HttpURLConnection with Apache HttpClient 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <java.version>1.8</java.version>
         <gson.version>2.8.9</gson.version>
         <slf4j.version>1.7.32</slf4j.version>
+        <httpclient5.version>5.4.3</httpclient5.version>
 
         <kafka-connect-maven-plugin.version>0.11.3</kafka-connect-maven-plugin.version>
         <kafka.version>2.5.0</kafka.version>
@@ -63,6 +64,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -16,8 +16,11 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.ParseException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -306,7 +309,16 @@ public class DatadogLogsApiWriter implements Closeable {
                 sendError[0] = new IOException("HTTP Response code: " + status
                         + ", " + response.getReasonPhrase() + ", " + error);
             } else {
-                log.trace("Received HTTP response {} {}", status, response.getReasonPhrase());
+                String body = "";
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    try {
+                        body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                    } catch (ParseException ignored) {
+                        // best-effort response body read
+                    }
+                }
+                log.trace("Received HTTP response {} {} with body {}", status, response.getReasonPhrase(), body);
             }
             return null;
         });

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -15,7 +15,6 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
@@ -46,17 +45,12 @@ import static java.util.stream.StreamSupport.stream;
 public class DatadogLogsApiWriter implements Closeable {
     public static final int MAXIMUM_BATCH_BYTES = 4500000;
 
-    /** Maximum total connections in the pool (shared across all routes). */
-    private static final int MAX_CONN_TOTAL = 50;
-
-    /** Maximum connections per route (there is only one route: the Datadog intake). */
-    private static final int MAX_CONN_PER_ROUTE = 50;
-
-    /** Connection-establishment timeout (milliseconds). */
+    // Matches the Datadog Agent's logs_config.http_timeout default (10s), which is the total
+    // budget that the Agent applies to the connect + write + read cycle of each intake request.
+    // Apache HttpClient 5's defaults (connect=3min, response=null/infinite) would let a stuck
+    // intake hang the connector indefinitely, so we set both legs explicitly.
     private static final int CONNECT_TIMEOUT_MS = 10_000;
-
-    /** Socket / response timeout (milliseconds). */
-    private static final int RESPONSE_TIMEOUT_MS = 30_000;
+    private static final int RESPONSE_TIMEOUT_MS = 10_000;
 
     private static final Logger log = LoggerFactory.getLogger(DatadogLogsApiWriter.class);
     private final DatadogLogsSinkConnectorConfig config;
@@ -78,17 +72,12 @@ public class DatadogLogsApiWriter implements Closeable {
     }
 
     private static CloseableHttpClient buildHttpClient(DatadogLogsSinkConnectorConfig config) {
-        PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
-        connManager.setMaxTotal(MAX_CONN_TOTAL);
-        connManager.setDefaultMaxPerRoute(MAX_CONN_PER_ROUTE);
-
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .setResponseTimeout(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .build();
 
         HttpClientBuilder builder = HttpClients.custom()
-                .setConnectionManager(connManager)
                 .setDefaultRequestConfig(requestConfig)
                 // Disable automatic decompression: we send gzip, not receive it.
                 .disableContentCompression()

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -301,16 +301,18 @@ public class DatadogLogsApiWriter implements Closeable {
                 throw new IOException("HTTP Response code: " + status
                         + ", " + response.getReasonPhrase() + ", " + error);
             }
-            String body = "";
-            HttpEntity entity = response.getEntity();
-            if (entity != null) {
-                try {
-                    body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-                } catch (ParseException ignored) {
-                    // best-effort response body read
+            if (log.isTraceEnabled()) {
+                String body = "";
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    try {
+                        body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                    } catch (IOException | ParseException ignored) {
+                        // best-effort body read for trace logging
+                    }
                 }
+                log.trace("Received HTTP response {} {} with body {}", status, response.getReasonPhrase(), body);
             }
-            log.trace("Received HTTP response {} {} with body {}", status, response.getReasonPhrase(), body);
             return null;
         });
 

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -10,6 +10,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -17,12 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -31,19 +36,33 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.StreamSupport.stream;
 
-public class DatadogLogsApiWriter {
+public class DatadogLogsApiWriter implements Closeable {
     public static final int MAXIMUM_BATCH_BYTES = 4500000;
+
+    /** Maximum total connections in the pool (shared across all routes). */
+    private static final int MAX_CONN_TOTAL = 50;
+
+    /** Maximum connections per route (there is only one route: the Datadog intake). */
+    private static final int MAX_CONN_PER_ROUTE = 50;
+
+    /** Connection-establishment timeout (milliseconds). */
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+
+    /** Socket / response timeout (milliseconds). */
+    private static final int RESPONSE_TIMEOUT_MS = 30_000;
 
     private static final Logger log = LoggerFactory.getLogger(DatadogLogsApiWriter.class);
     private final DatadogLogsSinkConnectorConfig config;
     private final Map<String, List<SinkRecord>> batches;
     private final JsonConverter jsonConverter;
+    private final CloseableHttpClient httpClient;
 
     public DatadogLogsApiWriter(DatadogLogsSinkConnectorConfig config) {
         this.config = config;
@@ -53,8 +72,35 @@ public class DatadogLogsApiWriter {
         Map<String, String> jsonConverterConfig = new HashMap<>();
         jsonConverterConfig.put("schemas.enable", "false");
         jsonConverterConfig.put("decimal.format", "NUMERIC");
-
         jsonConverter.configure(jsonConverterConfig, false);
+
+        this.httpClient = buildHttpClient(config);
+    }
+
+    private static CloseableHttpClient buildHttpClient(DatadogLogsSinkConnectorConfig config) {
+        PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+        connManager.setMaxTotal(MAX_CONN_TOTAL);
+        connManager.setDefaultMaxPerRoute(MAX_CONN_PER_ROUTE);
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .setResponseTimeout(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .build();
+
+        HttpClientBuilder builder = HttpClients.custom()
+                .setConnectionManager(connManager)
+                .setDefaultRequestConfig(requestConfig)
+                // Disable automatic decompression: we send gzip, not receive it.
+                .disableContentCompression()
+                // Disable automatic redirect following to keep behaviour identical to HttpURLConnection defaults.
+                .disableRedirectHandling();
+
+        if (config.proxyURL != null && !config.proxyURL.isEmpty()) {
+            HttpHost proxy = new HttpHost(config.proxyURL, config.proxyPort);
+            builder.setProxy(proxy);
+        }
+
+        return builder.build();
     }
 
     /**
@@ -234,58 +280,63 @@ public class DatadogLogsApiWriter {
     private void sendRequest(String requestContent, URL url) throws IOException {
         byte[] compressedPayload = compress(requestContent);
 
-        HttpURLConnection con;
-        if (config.proxyURL != null) {
-            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(config.proxyURL, config.proxyPort));
-            con = (HttpURLConnection) url.openConnection(proxy);
-        } else {
-            con = (HttpURLConnection) url.openConnection();
-        }
-        con.setDoOutput(true);
-        con.setRequestMethod("POST");
-        setRequestProperties(con);
+        String urlString = url.toString();
+        HttpPost request = new HttpPost(urlString);
 
-        log.trace("Submitting HTTP request to {} with body {}", con.getURL(), requestContent);
-        DataOutputStream output = new DataOutputStream(con.getOutputStream());
-        output.write(compressedPayload);
-        output.close();
-        log.trace("HTTP request submitted");
+        request.setHeader("Content-Type", "application/json");
+        request.setHeader("Content-Encoding", "gzip");
+        request.setHeader("DD-API-KEY", config.ddApiKey);
+        request.setHeader("DD-EVP-ORIGIN", Project.getName());
+        request.setHeader("DD-EVP-ORIGIN-VERSION", Project.getVersion());
+        request.setHeader("User-Agent", Project.getName() + "/" + Project.getVersion());
 
-        // get response
-        int status = con.getResponseCode();
-        if (!isSuccessfulHttpStatus(status)) {
-            InputStream stream = con.getErrorStream();
-            String error = "";
-            if (stream != null) {
-                error = getOutput(stream);
+        request.setEntity(new ByteArrayEntity(compressedPayload, ContentType.APPLICATION_JSON));
+
+        log.trace("Submitting HTTP request to {} with body {}", urlString, requestContent);
+
+        final IOException[] sendError = {null};
+        httpClient.execute(request, response -> {
+            int status = response.getCode();
+            if (!isSuccessfulHttpStatus(status)) {
+                String error = "";
+                if (response.getEntity() != null) {
+                    try {
+                        ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
+                        byte[] buf = new byte[1024];
+                        java.io.InputStream errorStream = response.getEntity().getContent();
+                        int len;
+                        while ((len = errorStream.read(buf)) != -1) {
+                            errorOutput.write(buf, 0, len);
+                        }
+                        error = errorOutput.toString(StandardCharsets.UTF_8.name());
+                    } catch (IOException ignored) {
+                        // best-effort error body read
+                    }
+                }
+                log.error("Http request failed with status: {}", status);
+                sendError[0] = new IOException("HTTP Response code: " + status
+                        + ", " + response.getReasonPhrase() + ", " + error);
+            } else {
+                log.trace("Received HTTP response {} {}", status, response.getReasonPhrase());
             }
+            return null;
+        });
 
-            con.disconnect();
-            log.error(String.format("Http request failed with status: %s", status));
-            throw new IOException("HTTP Response code: " + status
-                    + ", " + con.getResponseMessage() + ", " + error);
+        if (sendError[0] != null) {
+            throw sendError[0];
         }
 
-        log.trace("Received HTTP response {} {} with body {}", status, con.getResponseMessage(), getOutput(con.getInputStream()));
+        log.trace("HTTP request submitted");
     }
 
     /**
      * Check if the HTTP status code indicates success (2xx range)
-     * 
+     *
      * @param statusCode HTTP status code to check
      * @return true if status code is in the 2xx range (200-299)
      */
     private boolean isSuccessfulHttpStatus(int statusCode) {
         return statusCode >= 200 && statusCode < 300;
-    }
-
-    private void setRequestProperties(HttpURLConnection con) {
-        con.setRequestProperty("Content-Type", "application/json");
-        con.setRequestProperty("Content-Encoding", "gzip");
-        con.setRequestProperty("DD-API-KEY", config.ddApiKey);
-        con.setRequestProperty("DD-EVP-ORIGIN", Project.getName());
-        con.setRequestProperty("DD-EVP-ORIGIN-VERSION", Project.getVersion());
-        con.setRequestProperty("User-Agent", Project.getName() + "/" + Project.getVersion());
     }
 
     private byte[] compress(String str) throws IOException {
@@ -297,14 +348,8 @@ public class DatadogLogsApiWriter {
         return os.toByteArray();
     }
 
-    private String getOutput(InputStream input) throws IOException {
-        ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
-        byte[] buffer = new byte[1024];
-        int length;
-        while ((length = input.read(buffer)) != -1) {
-            errorOutput.write(buffer, 0, length);
-        }
-
-        return errorOutput.toString(StandardCharsets.UTF_8.name());
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
     }
 }

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsApiWriter.java
@@ -286,46 +286,33 @@ public class DatadogLogsApiWriter implements Closeable {
 
         log.trace("Submitting HTTP request to {} with body {}", urlString, requestContent);
 
-        final IOException[] sendError = {null};
         httpClient.execute(request, response -> {
             int status = response.getCode();
             if (!isSuccessfulHttpStatus(status)) {
                 String error = "";
                 if (response.getEntity() != null) {
                     try {
-                        ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
-                        byte[] buf = new byte[1024];
-                        java.io.InputStream errorStream = response.getEntity().getContent();
-                        int len;
-                        while ((len = errorStream.read(buf)) != -1) {
-                            errorOutput.write(buf, 0, len);
-                        }
-                        error = errorOutput.toString(StandardCharsets.UTF_8.name());
-                    } catch (IOException ignored) {
+                        error = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                    } catch (IOException | ParseException ignored) {
                         // best-effort error body read
                     }
                 }
                 log.error("Http request failed with status: {}", status);
-                sendError[0] = new IOException("HTTP Response code: " + status
+                throw new IOException("HTTP Response code: " + status
                         + ", " + response.getReasonPhrase() + ", " + error);
-            } else {
-                String body = "";
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    try {
-                        body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-                    } catch (ParseException ignored) {
-                        // best-effort response body read
-                    }
-                }
-                log.trace("Received HTTP response {} {} with body {}", status, response.getReasonPhrase(), body);
             }
+            String body = "";
+            HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                try {
+                    body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                } catch (ParseException ignored) {
+                    // best-effort response body read
+                }
+            }
+            log.trace("Received HTTP response {} {} with body {}", status, response.getReasonPhrase(), body);
             return null;
         });
-
-        if (sendError[0] != null) {
-            throw sendError[0];
-        }
 
         log.trace("HTTP request submitted");
     }

--- a/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkTask.java
+++ b/src/main/java/com/datadoghq/connect/logs/sink/DatadogLogsSinkTask.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -39,6 +40,13 @@ public class DatadogLogsSinkTask extends SinkTask {
     }
 
     protected void initWriter() {
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                log.warn("Error closing previous HTTP client before reinitialising writer", e);
+            }
+        }
         writer = new DatadogLogsApiWriter(config);
     }
 
@@ -101,6 +109,13 @@ public class DatadogLogsSinkTask extends SinkTask {
     @Override
     public void stop() {
         log.info("Stopping task with config={}", config);
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                log.warn("Error closing HTTP client during stop", e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Replaces `HttpURLConnection` in `DatadogLogsApiWriter` with Apache HttpClient 5.x (`httpclient5` 5.4.3), the current stable major.
- Sets explicit connect (10s) and response (10s) timeouts via `RequestConfig`. **These values match the Datadog Agent's `logs_config.http_timeout` default** (a single 10s budget covering the connect + write + read cycle of each intake request — see [`pkg/config/setup/common_settings.go:1845`](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/common_settings.go#L1845) and [`comp/logs-library/client/http/destination.go:455`](https://github.com/DataDog/datadog-agent/blob/main/comp/logs-library/client/http/destination.go#L455)). Library defaults are unsafe (`connectTimeout=3min`, `responseTimeout=null`/infinite), so the pair must be set explicitly.
- **No custom connection pool.** Kafka Connect calls `put()` on a single thread per task, so at most one concurrent HTTP send is in flight — the library's default `PoolingHttpClientConnectionManager` (`maxTotal=25`, `maxPerRoute=5`) is already several × oversized.
- All existing connector behaviour is preserved exactly: same HTTP headers (`DD-API-KEY`, `DD-EVP-ORIGIN`, `DD-EVP-ORIGIN-VERSION`, `User-Agent`), same gzip body compression, same proxy support via `datadog.proxy.url`/`datadog.proxy.port`, same error handling (non-2xx throws `IOException`).
- `DatadogLogsApiWriter` now implements `Closeable`; `DatadogLogsSinkTask.stop()` and the retry reinit path both call `close()` so the underlying HttpClient is released on connector shutdown.
- Apache HttpClient 5.x is shaded into the connector JAR by the existing `maven-shade-plugin` configuration, eliminating any Kafka Connect runtime classpath conflict.

## Risk assessment

The swap is not breaking. The HTTP transport is entirely internal to `DatadogLogsApiWriter` — no public API surface (constructor signature, `write()` method, config keys) changes. All existing config keys map to Apache HttpClient settings with identical semantics. The shaded JAR means zero runtime classpath risk for Kafka Connect operators. JDK floor is Java 8; Apache HttpClient 5.x supports JDK 8+.

## Manual QA

Verified against Java 8 + Maven via Docker (the host machine has no JDK):

```
docker run --rm -v "$PWD":/work -v "$HOME/.m2":/root/.m2 -w /work \
  maven:3-eclipse-temurin-8 mvn -B test
```

**Result:** `Tests run: 24, Failures: 0, Errors: 0, Skipped: 0` — `BUILD SUCCESS`. The existing `DatadogLogsApiWriterTest` suite exercises all key behaviours via an embedded Jetty server (correct URL, headers, gzip body, batch splitting, 429/error status handling, proxy-less path).

**Shade verification** (separately confirmed in this branch): `mvn -B package` followed by `jar tf target/datadog-kafka-connect-logs-*.jar | grep 'org/apache/hc/client5/'` shows the HttpClient 5.x classes are shaded inside the connector JAR — no runtime classpath risk to Kafka Connect workers.

## Checklist
- [x] No public API changes
- [x] All existing config keys preserved with identical semantics
- [x] Proxy support preserved
- [x] Graceful resource cleanup (Closeable + close() in stop() and retry reinit)
- [x] Unit tests green (24/24 via Docker)
- [x] Shaded JAR verified to contain HttpClient 5 classes
- [x] HTTP timeouts justified — match Datadog Agent's `logs_config.http_timeout` default

Closes AGNTLOG-200