### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+# 1.5.0 / 2026-06-18
+
+### Changes
+
+* Replaced `HttpURLConnection` with Apache HttpClient 5.x for the Datadog logs
+  sink transport.
+* Fixed batch size tracking to use accurate UTF-8 byte counts rather than
+  character counts, preventing oversized payloads from being submitted.
+* Fixed a sink connector issue reported in
+  [#59](https://github.com/DataDog/datadog-kafka-connect-logs/pull/59).
+* Migrated CI from CircleCI to GitHub Actions.
+* Added devcontainer support for local development.
+
+# 1.4.0 / 2025-08-11
+
+### Changes
+
+* Added support for Confluent Platform 8.0.0 by removing the `javax` dependency
+  to maintain Kafka version interoperability.
+
 # 1.3.0 / 2024-05-24
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ Changelog
   character counts, preventing oversized payloads from being submitted.
 * Fixed a sink connector issue reported in
   [#59](https://github.com/DataDog/datadog-kafka-connect-logs/pull/59).
-* Migrated CI from CircleCI to GitHub Actions.
-* Added devcontainer support for local development.
 
 # 1.4.0 / 2025-08-11
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 


### PR DESCRIPTION
## Summary

Cuts the 1.5.0 release.

### Changes included since 1.4.0
- Replaced `HttpURLConnection` with Apache HttpClient 5.x for the Datadog logs sink transport (#65)
- Fixed batch size tracking to use accurate UTF-8 byte counts rather than character counts (#64)
- Fixed sink connector issue from #59
- Migrated CI from CircleCI to GitHub Actions (#63)
- Added devcontainer support (#55)

### Release housekeeping
- Bump `pom.xml` version: `1.4.0` → `1.5.0`
- Add `1.5.0 / 2026-06-18` entry to `CHANGELOG.md`
- Backfill the previously-missing `1.4.0 / 2025-08-11` `CHANGELOG.md` entry

### Local build
Built with `maven:3.9-eclipse-temurin-8` (matches devcontainer's Java 8 + Maven):
- `BUILD SUCCESS`
- 24/24 tests pass (0 failures, 0 errors, 0 skipped)
- Produces `target/datadog-kafka-connect-logs-1.5.0.jar` and `target/components/packages/datadog-kafka-connect-logs-1.5.0.zip`

## Test plan
- [ ] CI green on this branch
- [ ] After merge: tag `1.5.0` on the merge commit and push
- [ ] Create GitHub release `1.5.0` with the built jar + zip attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)