### PR TITLE
Bump pom.xml to 1.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://www.datadoghq.com/</url>
     </organization>
     <name>datadog-kafka-connect-logs</name>
-    <version>1.5.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <description>A Kafka Connect Connector that sends Kafka Connect records as logs to the Datadog API.</description>
     <url>https://github.com/DataDog/datadog-kafka-connect-logs</url>
 


### PR DESCRIPTION
## Summary

Post-release housekeeping after [1.5.0](https://github.com/DataDog/datadog-kafka-connect-logs/releases/tag/1.5.0): bumps `pom.xml` from `1.5.0` → `1.6.0-SNAPSHOT` per [step 6 of the official release process](https://datadoghq.atlassian.net/wiki/spaces/AL/pages/2812772702/Datadog+Kafka+Connect+Logs#To-Release).

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)